### PR TITLE
tweak to presentation routine to allow ordering

### DIFF
--- a/SMCalloutView.h
+++ b/SMCalloutView.h
@@ -32,7 +32,7 @@ extern NSTimeInterval kSMCalloutViewRepositionDelayForUIScrollView;
 // Presents a callout view by adding it to "inView" and pointing at the given rect of inView's bounds.
 // Constrains the callout to the bounds of the given view. Optionally scrolls the given rect into view (plus margins)
 // if -delegate is set and responds to -delayForRepositionWithSize.
-- (void)presentCalloutFromRect:(CGRect)rect inView:(UIView *)view aboveSubview:(UIView *)subview constrainedToView:(UIView *)constrainedView permittedArrowDirections:(SMCalloutArrowDirection)arrowDirections animated:(BOOL)animated;
+- (void)presentCalloutFromRect:(CGRect)rect inLayer:(CALayer *)layer constrainedToLayer:(CALayer *)constrainedLayer permittedArrowDirections:(SMCalloutArrowDirection)arrowDirections animated:(BOOL)animated;
 
 - (void)dismissCalloutAnimated:(BOOL)animated;
 

--- a/SMCalloutView.m
+++ b/SMCalloutView.m
@@ -163,10 +163,10 @@ NSTimeInterval kSMCalloutViewRepositionDelayForUIScrollView = 1.0/3.0;
     return CGSizeMake(nudgeLeft ?: nudgeRight, nudgeTop ?: nudgeBottom);
 }
 
-- (void)presentCalloutFromRect:(CGRect)rect inView:(UIView *)view aboveSubview:(UIView *)subview constrainedToView:(UIView *)constrainedView permittedArrowDirections:(SMCalloutArrowDirection)arrowDirections animated:(BOOL)animated {
+- (void)presentCalloutFromRect:(CGRect)rect inLayer:(CALayer *)layer constrainedToLayer:(CALayer *)constrainedLayer permittedArrowDirections:(SMCalloutArrowDirection)arrowDirections animated:(BOOL)animated {
 
     // figure out the constrained view's rect in our popup view's coordinate system
-    CGRect constrainedRect = [constrainedView convertRect:constrainedView.bounds toView:view];
+    CGRect constrainedRect = [constrainedLayer convertRect:constrainedLayer.bounds toLayer:layer];
 
     // form our subviews based on our content set so far
     [self rebuildSubviews];
@@ -215,11 +215,8 @@ NSTimeInterval kSMCalloutViewRepositionDelayForUIScrollView = 1.0/3.0;
     if (anchorX < minPointX) adjustX = anchorX - minPointX;
     if (anchorX > maxPointX) adjustX = anchorX - maxPointX;
 
-    // add the callout to the given view
-    if (subview)
-        [view insertSubview:self aboveSubview:subview];
-    else
-        [view addSubview:self];
+    // add the callout to the given layer
+    [layer addSublayer:self.layer];
 
     CGPoint calloutOrigin = {
         .x = calloutX + adjustX,
@@ -229,7 +226,7 @@ NSTimeInterval kSMCalloutViewRepositionDelayForUIScrollView = 1.0/3.0;
     self.$origin = calloutOrigin;
     
     // now set the *actual* anchor point for our layer so that our "popup" animation starts from this point.
-    CGPoint anchorPoint = [view convertPoint:CGPointMake(anchorX, anchorY) toView:self];
+    CGPoint anchorPoint = [layer convertPoint:CGPointMake(anchorX, anchorY) toLayer:self.layer];
     anchorPoint.x /= self.$width;
     anchorPoint.y /= self.$height;
     self.layer.anchorPoint = anchorPoint;


### PR DESCRIPTION
When integrating this into our SDK, I hit the problem of needing to specify ordering of the callout within its new superview. I extended your presentation routine to allow for a view to place the callout above. 

Ideally, I think this would be best suited by three presentation methods with common base code, but different view insertion -- one as you had before, one with an `aboveSubview:` argument as I needed, and one with a `belowSubview:` argument for completeness. But seeing as the view insertion is in the middle of the routine, common base code for all the other stuff is tricky. I figured I'd run this by you first and see what your thoughts where. 
