### PR TITLE
Fix for unwanted behaviour

### DIFF
--- a/SMCalloutView.m
+++ b/SMCalloutView.m
@@ -314,11 +314,11 @@ NSTimeInterval kSMCalloutViewRepositionDelayForUIScrollView = 1.0/3.0;
 - (void)animationDidStop:(CAAnimation *)anim finished:(BOOL)finished {
     BOOL presenting = [[anim valueForKey:@"presenting"] boolValue];
     
-    if (finished && presenting) {
+    if (presenting) {
         if ([_delegate respondsToSelector:@selector(calloutViewDidAppear:)])
             [_delegate calloutViewDidAppear:self];
     }
-    else if (finished && !presenting) {
+    else if (!presenting) {
         
         // removing a layer from a superlayer causes an implicit fade-out animation that we wish to disable.
         [CATransaction begin];


### PR DESCRIPTION
Fixes situation where after calling dismissCalloutAnimated:YES before presentCallout... would result unwanted behaviour because other animation is still on layer.

It happens because after calling dismissCalloutAnimated:YES second time, the SMCalloutView is not on any view (has no superview) and so it finishes with finished parameter false. After that the "dismiss" animation won't be removed so when "present" animation finishes, "dismiss" animation (opacity:0) will be shown.
