### PR TITLE
properly dismiss when using layers & not animated

### DIFF
--- a/SMCalloutView.m
+++ b/SMCalloutView.m
@@ -357,7 +357,18 @@ NSTimeInterval kSMCalloutViewRepositionDelayForUIScrollView = 1.0/3.0;
         animation.delegate = self;
         [self.layer addAnimation:animation forKey:@"dismiss"];
     }
-    else [self removeFromSuperview];
+    else {
+        if (self.superview)
+            [self removeFromSuperview];
+        else {
+            [CATransaction begin];
+            [CATransaction setDisableActions:YES];
+
+            [self.layer removeFromSuperlayer];
+
+            [CATransaction commit];
+        }
+    }
 }
 
 - (CAAnimation *)animationWithType:(SMCalloutAnimation)type presenting:(BOOL)presenting {


### PR DESCRIPTION
When using the layers display method instead of the views one, when calling `dismissCalloutAnimated:NO`, it animates anyway because layer property animations aren't disabled. This fixes that. 
