### PR TITLE
Take constrainedInsets in SMClassicCalloutView

### DIFF
--- a/SMClassicCalloutView.m
+++ b/SMClassicCalloutView.m
@@ -209,6 +209,7 @@
     
     // figure out the constrained view's rect in our popup view's coordinate system
     CGRect constrainedRect = [constrainedLayer convertRect:constrainedLayer.bounds toLayer:layer];
+    constrainedRect = UIEdgeInsetsInsetRect(constrainedRect, self.constrainedInsets);
     
     // form our subviews based on our content set so far
     [self rebuildSubviews];


### PR DESCRIPTION
constrainedInsets are ignored in SMClassicCalloutView making repositioning of the map harder to perform in IOS7 when using MapView with transparent Navigation or Tool bars.
