### PR TITLE
Remove content view subviews when rebuilding subviewviews

### DIFF
--- a/SMCalloutView.m
+++ b/SMCalloutView.m
@@ -126,6 +126,7 @@ NSTimeInterval kSMCalloutViewRepositionDelayForUIScrollView = 1.0/3.0;
 - (void)rebuildSubviews {
     // remove and re-add our appropriate subviews in the appropriate order
     [self.subviews makeObjectsPerformSelector:@selector(removeFromSuperview)];
+    [self.containerView.subviews makeObjectsPerformSelector:@selector(removeFromSuperview)];
     [self setNeedsDisplay];
     
     [self addSubview:self.backgroundView];


### PR DESCRIPTION
Old contentView was never removed when a new contentView was set.
