### PR TITLE
NS_OPTIONS for arrow direction, const scroll view reposition delay

### DIFF
--- a/SMCalloutView.h
+++ b/SMCalloutView.h
@@ -11,9 +11,9 @@ Version 2.0.3
 */
 
 // options for which directions the callout is allowed to "point" in.
-typedef NS_ENUM(NSUInteger, SMCalloutArrowDirection) {
-    SMCalloutArrowDirectionUp = 1UL << 0,
-    SMCalloutArrowDirectionDown = 1UL << 1,
+typedef NS_OPTIONS(NSUInteger, SMCalloutArrowDirection) {
+    SMCalloutArrowDirectionUp = 1 << 0,
+    SMCalloutArrowDirectionDown = 1 << 1,
     SMCalloutArrowDirectionAny = SMCalloutArrowDirectionUp | SMCalloutArrowDirectionDown
 };
 
@@ -26,7 +26,7 @@ typedef NS_ENUM(NSInteger, SMCalloutAnimation) {
 
 // when delaying our popup in order to scroll content into view, you can use this amount to match the
 // animation duration of UIScrollView when using -setContentOffset:animated.
-extern NSTimeInterval kSMCalloutViewRepositionDelayForUIScrollView;
+extern NSTimeInterval const kSMCalloutViewRepositionDelayForUIScrollView;
 
 @protocol SMCalloutViewDelegate;
 @class SMCalloutBackgroundView;

--- a/SMCalloutView.m
+++ b/SMCalloutView.m
@@ -31,7 +31,7 @@
 #define TOP_ANCHOR_MARGIN 13 // all the above measurements assume a bottom anchor! if we're pointing "up" we'll need to add this top margin to everything.
 #define COMFORTABLE_MARGIN 10 // when we try to reposition content to be visible, we'll consider this margin around your target rect
 
-NSTimeInterval kSMCalloutViewRepositionDelayForUIScrollView = 1.0/3.0;
+NSTimeInterval const kSMCalloutViewRepositionDelayForUIScrollView = 1.0/3.0;
 
 @interface SMCalloutView ()
 @property (nonatomic, strong) UIButton *containerView; // for masking and interaction


### PR DESCRIPTION
Just two minor things. Using NS_OPTIONS improves the Swift compatibility of the arrow direction
