### PR TITLE
Added containerview to backgroundview.subviews

### DIFF
--- a/SMCalloutView.m
+++ b/SMCalloutView.m
@@ -138,7 +138,7 @@ NSTimeInterval const kSMCalloutViewRepositionDelayForUIScrollView = 1.0/3.0;
     [self setNeedsDisplay];
     
     [self addSubview:self.backgroundView];
-    [self addSubview:self.containerView];
+    [self.backgroundView addSubview:self.containerView];
     
     if (self.contentView) {
         [self.containerView addSubview:self.contentView];


### PR DESCRIPTION
Hey,

I've made this change because I had a problem:
I added a custom titleView and a custom backgroundView. 
If the backgroundView has an opacity from, for example, 50%, the titleView has the same opacity.
Once I added the containerView as a subview of backgroundView all was fine.