### PR TITLE
Fixed colliding animations

### DIFF
--- a/SMCalloutView.m
+++ b/SMCalloutView.m
@@ -269,8 +269,9 @@ NSTimeInterval const kSMCalloutViewRepositionDelayForUIScrollView = 1.0/3.0;
     // Sanity check: dismiss this callout immediately if it's displayed somewhere
     if (self.layer.superlayer) [self dismissCalloutAnimated:NO];
     
-    // cancel any presenting animation that may be in progress
+    // cancel all animations that may be in progress
     [self.layer removeAnimationForKey:@"present"];
+    [self.layer removeAnimationForKey:@"dismiss"];
 
     // figure out the constrained view's rect in our popup view's coordinate system
     CGRect constrainedRect = [constrainedLayer convertRect:constrainedLayer.bounds toLayer:layer];


### PR DESCRIPTION
I noticed that sometimes the callout appeared and immediately disappeared -- turns out the animations were colliding.

To repeat issue:

1. use SMCalloutView with an MKMapView on iOS 9.2
2. have more than one annotation visible on the map so that the map does not need to scroll between callouts
3. also have a current location annotation on the same map
4. touch an annotation to show the SMCalloutView
5. touch the current location annotation to show the built-in "Current Location" callout -- the SMCalloutView will correctly disappear
6. touch another annotation -- the SMCalloutView will appear and immediately disappear

Debug logging showed that the animations were getting out of order even though the `dismissCalloutAnimated:` was called before the `presentCalloutFromRect:...` method.

The "present" animation was not assigned a delay as there was no need to move the map, so the animations could happen in any order. For some reason, showing the current location callout triggered a switch in the order.