### PR TITLE
Explicitly set CAAnimationDelegate for iOS 10

### DIFF
--- a/SMCalloutView.h
+++ b/SMCalloutView.h
@@ -40,7 +40,12 @@ extern NSTimeInterval const kSMCalloutViewRepositionDelayForUIScrollView;
 // Callout view.
 //
 
+// iOS 10+ expects CAAnimationDelegate to be set explicitly.
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 100000
 @interface SMCalloutView : UIView
+#else
+@interface SMCalloutView : UIView <CAAnimationDelegate>
+#endif
 
 @property (nonatomic, weak, nullable) id<SMCalloutViewDelegate> delegate;
 /// title/titleView relationship mimics UINavigationBar.


### PR DESCRIPTION
Explicitly sets [CAAnimationDelegate](https://developer.apple.com/reference/quartzcore/caanimationdelegate) on SMCalloutView, which fixes build warnings brought about by changes in iOS 10:

```
SMCalloutView/SMCalloutView.m:401:24: assigning to 'id<CAAnimationDelegate> _Nullable' from incompatible type 'SMCalloutView *const __strong'

    animation.delegate = self;
                       ^ ~~~~
```